### PR TITLE
fix audio player caching

### DIFF
--- a/audio/models/PlayMeow.model.bxb
+++ b/audio/models/PlayMeow.model.bxb
@@ -1,17 +1,22 @@
+// To play audio, there is a two step process
+// First create the playlist (done via mwowToPlay below)
+// Second, pass the playlist to the audioPlayer (done via meow below)
+
 action (PlayMeow) {
   type (Search)
   collect {
-    input (meowToPlay) {
+    computed-input (meowToPlay) {
+      description (Create the playlist to play)
       type (audioPlayer.AudioInfo)
       min (Required) max (One)
-      default-init {
+      compute {
         intent {
           goal: BuildMeowAudioInfo
         }
       }
-      hidden
+      hidden     
     }
-
+    
     computed-input (meow) {
       description (By passing in the AudioInfo object to the PlayAudio action, we ask the client to play our sound.)
       type (audioPlayer.Result)

--- a/audio/models/PlayMeow.model.bxb
+++ b/audio/models/PlayMeow.model.bxb
@@ -1,5 +1,5 @@
 // To play audio, there is a two step process
-// First create the playlist (done via mwowToPlay below)
+// First create the playlist (done via meowToPlay below)
 // Second, pass the playlist to the audioPlayer (done via meow below)
 
 action (PlayMeow) {


### PR DESCRIPTION
Use computed input rather than default-init to avoid caching issues - does not show up in the meow example but if the example is used for something that dynamically plays audio it will show up.