### PR TITLE
Meow search term

### DIFF
--- a/audio/capsule.bxb
+++ b/audio/capsule.bxb
@@ -1,6 +1,6 @@
 capsule {
   id (example.meow)
-  version (0.1.0)
+  version (0.2.0)
   format (3)
   targets {
     target (bixby-mobile-en-US)

--- a/audio/code/BuildMeowAudioInfo.js
+++ b/audio/code/BuildMeowAudioInfo.js
@@ -3,7 +3,7 @@ module.exports.function = function buildMeowAudioInfo(meowAudio) {
 
   /* Since meowAudio are already in audioItem format this mapping is not necessary, but
   this demonstrates how to build the right structure for audioItem and audioInfo */
-  
+
   audioInfo.audioItem = meowAudio.map(function (audioItem) {
     let audioItemStructure = { //required properties of audioItem
       id: audioItem.id,
@@ -24,8 +24,6 @@ module.exports.function = function buildMeowAudioInfo(meowAudio) {
     }
     return audioItemStructure
   });
-
-  audioInfo.audioItem = meowAudio
 
   audioInfo.category = 'RADIO';
   audioInfo.displayName = 'Meow Capsule';

--- a/audio/code/BuildMeowAudioInfo.js
+++ b/audio/code/BuildMeowAudioInfo.js
@@ -1,52 +1,37 @@
-module.exports.function = function findMeow () {
-  var input = {};
+module.exports.function = function buildMeowAudioInfo(meowAudio) {
+  var audioInfo = {};
+
+  /* Since meowAudio are already in audioItem format this mapping is not necessary, but
+  this demonstrates how to build the right structure for audioItem and audioInfo */
   
-  input.audioItem = [{
-    id: 1,
-    stream: [
-      {
-        url: "https://storage.googleapis.com/bixby-audio-player-example/meows/203121_777645-lq.mp3",
-        format: "mp3"
-      }
-    ],
-    title: "Cat-ch Phrase",
-    subtitle: "Meow.",
-    artist: "Cool Cat",
-    albumName: "Catatonic",
-    albumArtUrl: "https://storage.googleapis.com/bixby-audio-player-example/meows/cat-08.jpg"
-  },
-  {
-    id: 2,
-    stream: [
-      {
-        url: "https://storage.googleapis.com/bixby-audio-player-example/meows/385892_2322725-lq.mp3",
-        format: "mp3"
-      }
-    ],
-    title: "Fur Real?",
-    subtitle: "Meow meow.",
-    artist: "Tom Cat",
-    albumName: "You gotta be kitten me!",
-    albumArtUrl: "https://storage.googleapis.com/bixby-audio-player-example/meows/cat-in-a-basket.jpg"
-  },
-  {
-    id: 3,
-    stream: [
-      {
-        url: "https://storage.googleapis.com/bixby-audio-player-example/meows/211687_1979597-lq.mp3",
-        format: "mp3"
-      }
-    ],
-    title: "Mew-sic",
-    subtitle: "Meow meow meow.",
-    artist: "Radi-claw",
-    albumArtUrl: "https://storage.googleapis.com/bixby-audio-player-example/meows/cat.png"
-  }]
-  
-  input.category = 'RADIO';
-  input.displayName = 'Meow Capsule';
-  input.repeatMode = 'ALL';
-  
-  return input;
+  audioInfo.audioItem = meowAudio.map(function (audioItem) {
+    let audioItemStructure = { //required properties of audioItem
+      id: audioItem.id,
+      stream: audioItem.stream,
+      title: audioItem.title,
+      artist:audioItem.artist,
+      albumArtUrl: audioItem.albumArtUrl
+    }
+    //optional properties of audioItem
+    if (audioItem.subtitle) {
+      audioItemStructure.subtitle = audioItem.subtitle
+    }
+    if (audioItem.albumName) {
+      audioItemStructure.albumName = audioItem.albumName
+    }
+    if (audioItem.duration) {
+      audioItemStructure.duration = audioItem.duration
+    }
+    return audioItemStructure
+  });
+
+  audioInfo.audioItem = meowAudio
+
+  audioInfo.category = 'RADIO';
+  audioInfo.displayName = 'Meow Capsule';
+  audioInfo.repeatMode = 'ALL';
+  audioInfo.doNotWaitForTTS = false;
+
+  return audioInfo;
 }
 

--- a/audio/code/FindMeow.js
+++ b/audio/code/FindMeow.js
@@ -1,0 +1,25 @@
+var meowAudio = require('./meowAudio.js')
+
+module.exports.function = function findMeow(searchTerm) {
+    let meowAudioFound = []
+
+    if (searchTerm) {
+        meowAudioFound = meowAudio.audioItems.filter(function (audioItem) {
+            if (audioItem.title.includes(searchTerm)) {
+                return true
+            } else if (audioItem.artist.includes(searchTerm)) {
+                return true
+            } else if (audioItem.subtitle && audioItem.subtitle.includes(searchTerm)) {
+                return true
+            } else if (audioItem.albumName && audioItem.albumName.includes(searchTerm)) {
+                return true
+            } else {
+                return false
+            }
+        })
+    } else {
+        meowAudioFound = meowAudio.audioItems
+    }
+
+    return meowAudioFound
+}

--- a/audio/code/FindMeow.js
+++ b/audio/code/FindMeow.js
@@ -1,25 +1,22 @@
 var meowAudio = require('./meowAudio.js')
 
 module.exports.function = function findMeow(searchTerm) {
+    const keysToSearchOn = ['title', 'artist', 'subtitle', 'albumName']
     let meowAudioFound = []
 
     if (searchTerm) {
+        searchTerm = searchTerm.toLowerCase()
         meowAudioFound = meowAudio.audioItems.filter(function (audioItem) {
-            if (audioItem.title.includes(searchTerm)) {
-                return true
-            } else if (audioItem.artist.includes(searchTerm)) {
-                return true
-            } else if (audioItem.subtitle && audioItem.subtitle.includes(searchTerm)) {
-                return true
-            } else if (audioItem.albumName && audioItem.albumName.includes(searchTerm)) {
-                return true
-            } else {
-                return false
-            }
+            keysToSearchOn.some(function (key) {
+                return audioItem[key] && audioItem[key].toLowerCase().includes(searchTerm)
+            })
         })
     } else {
         meowAudioFound = meowAudio.audioItems
     }
 
     return meowAudioFound
+}
+function checkMatch(audioItem, searchTerm) {
+    return (audioItem[])
 }

--- a/audio/code/FindMeow.js
+++ b/audio/code/FindMeow.js
@@ -17,6 +17,3 @@ module.exports.function = function findMeow(searchTerm) {
 
     return meowAudioFound
 }
-function checkMatch(audioItem, searchTerm) {
-    return (audioItem[])
-}

--- a/audio/code/meowAudio.js
+++ b/audio/code/meowAudio.js
@@ -1,0 +1,43 @@
+const audioItems = [{
+    id: 1,
+    stream: [
+      {
+        url: "https://storage.googleapis.com/bixby-audio-player-example/meows/203121_777645-lq.mp3",
+        format: "mp3"
+      }
+    ],
+    title: "Cat-ch Phrase",
+    subtitle: "Meow.",
+    artist: "Cool Cat",
+    albumName: "Catatonic",
+    albumArtUrl: "https://storage.googleapis.com/bixby-audio-player-example/meows/cat-08.jpg"
+  },
+  {
+    id: 2,
+    stream: [
+      {
+        url: "https://storage.googleapis.com/bixby-audio-player-example/meows/385892_2322725-lq.mp3",
+        format: "mp3"
+      }
+    ],
+    title: "Fur Real?",
+    subtitle: "Meow meow.",
+    artist: "Tom Cat",
+    albumName: "You gotta be kitten me!",
+    albumArtUrl: "https://storage.googleapis.com/bixby-audio-player-example/meows/cat-in-a-basket.jpg"
+  },
+  {
+    id: 3,
+    stream: [
+      {
+        url: "https://storage.googleapis.com/bixby-audio-player-example/meows/211687_1979597-lq.mp3",
+        format: "mp3"
+      }
+    ],
+    title: "Mew-sic",
+    subtitle: "Meow meow meow.",
+    artist: "Radi-claw",
+    albumArtUrl: "https://storage.googleapis.com/bixby-audio-player-example/meows/cat.png"
+  }]
+
+  exports.audioItems = audioItems

--- a/audio/models/BuildMeowAudioInfo.model.bxb
+++ b/audio/models/BuildMeowAudioInfo.model.bxb
@@ -1,5 +1,16 @@
 action (BuildMeowAudioInfo) {
   type (Search)
-  description (Makes a meow info to play.)
+  description (Makes a meow audio info, aka a playlist, to play.)
+  collect {
+    input (meowAudio) {
+      type (MeowAudio)
+      min (Required) max (Many)
+      default-init {
+        intent {
+          goal: FindMeow
+        }
+      }
+    }
+  }
   output (audioPlayer.AudioInfo)
 }

--- a/audio/models/FindMeow.model.bxb
+++ b/audio/models/FindMeow.model.bxb
@@ -1,0 +1,11 @@
+action (FindMeow) {
+  type (Search)
+  description (Finds meow audio item using a searchTerm)
+  collect {
+    input (searchTerm) {
+      type (SearchTerm)
+      min (Optional) max (One)
+    }
+  }
+  output (MeowAudio)
+}

--- a/audio/models/MeowAudio.model.bxb
+++ b/audio/models/MeowAudio.model.bxb
@@ -1,0 +1,3 @@
+structure (MeowAudio) {
+  role-of (audioPlayer.AudioItem)
+}

--- a/audio/models/PlayMeow.model.bxb
+++ b/audio/models/PlayMeow.model.bxb
@@ -4,19 +4,20 @@
 
 action (PlayMeow) {
   type (Search)
+  
   collect {
-    computed-input (meowToPlay) {
+    input (meowToPlay) {
       description (Create the playlist to play)
       type (audioPlayer.AudioInfo)
       min (Required) max (One)
-      compute {
+      default-init {
         intent {
           goal: BuildMeowAudioInfo
-        }
+        } 
       }
       hidden     
     }
-    
+
     computed-input (meow) {
       description (By passing in the AudioInfo object to the PlayAudio action, we ask the client to play our sound.)
       type (audioPlayer.Result)

--- a/audio/models/Result.model.bxb
+++ b/audio/models/Result.model.bxb
@@ -1,3 +1,3 @@
 text (Result) {
-  description (__DESCRIPTION__)
+  description (For confirmation on whether audio was played successfully or not)
 }

--- a/audio/models/SearchTerm.model.bxb
+++ b/audio/models/SearchTerm.model.bxb
@@ -1,0 +1,3 @@
+text (SearchTerm) {
+  description (text users use to search for content)
+}

--- a/audio/resources/en/endpoints.bxb
+++ b/audio/resources/en/endpoints.bxb
@@ -4,7 +4,12 @@ endpoints {
       local-endpoint (PlayMeow.js)
     }
     action-endpoint (BuildMeowAudioInfo) {
+      accepted-inputs (meowAudio)
       local-endpoint (BuildMeowAudioInfo.js)
+    }
+    action-endpoint (FindMeow) {
+      accepted-inputs (searchTerm)
+      local-endpoint (FindMeow.js)
     }
   }
 }

--- a/audio/resources/en/training/t-5.training.bxb
+++ b/audio/resources/en/training/t-5.training.bxb
@@ -1,0 +1,5 @@
+train (t-5jzs53d4ujwqrkocb5167dq1v) {
+  utterance ("[g:PlayMeow] play (Cool Cat)[v:SearchTerm]")
+  plan (Y2BnEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhikkzIrkir1EktTMvNBgqlFeo4gtmdeWj6DPIoep9LMnBSQJoQCMRQFcDk0y9wy88D6GMRRhINTE4uSM0JSi3IZ2BgYGZgYmBlYGFiBbAYkHiOYB8EMQFFGkDwA)
+  last-modified (1565661586527)
+}

--- a/audio/resources/en/training/t-9.training.bxb
+++ b/audio/resources/en/training/t-9.training.bxb
@@ -1,0 +1,5 @@
+train (t-9u1clfhr6sabjoxkad28j526x) {
+  utterance ("[g:PlayMeow] Play (Radi-claw)[v:SearchTerm]")
+  plan (Y2BnEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhikkzIrkir1EktTMvNBgqlFeo4gtmdeWj6DPIoep9LMnBSQJoQCMRQFcDk0y9wy88D6GMRRhINTE4uSM0JSi3IZ2BgYGZgYmBlYGFiBbAYkHiOYB8EMQFFGkDwA)
+  last-modified (1565661672005)
+}

--- a/audio/resources/en/training/t-9.training.bxb
+++ b/audio/resources/en/training/t-9.training.bxb
@@ -1,5 +1,0 @@
-train (t-9u1clfhr6sabjoxkad28j526x) {
-  utterance ("[g:PlayMeow] Play (Radi-claw)[v:SearchTerm]")
-  plan (Y2BnEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhikkzIrkir1EktTMvNBgqlFeo4gtmdeWj6DPIoep9LMnBSQJoQCMRQFcDk0y9wy88D6GMRRhINTE4uSM0JSi3IZ2BgYGZgYmBlYGFiBbAYkHiOYB8EMQFFGkDwA)
-  last-modified (1565661672005)
-}

--- a/audio/resources/en/training/t-b.training.bxb
+++ b/audio/resources/en/training/t-b.training.bxb
@@ -1,0 +1,10 @@
+train (t-borc151r6hm1ecrr9v9ln4wbw) {
+  utterance ("[g:PlayMeow] play (Tom Cat)[v:SearchTerm]")
+  plan (Y2BnEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhikkzIrkir1EktTMvNBgqlFeo4gtmdeWj6DPIoep9LMnBSQJoQCMRQFcDk0y9wy88D6GMRRhINTE4uSM0JSi3IZ2BgYGZgYmBlYGFiBbAYkHiOYB8EMQFFGkDwA)
+  last-modified (1565661645703)
+}
+train (t-bz3njxox15pj0xveq9jm945q1) {
+  utterance ("[g:PlayMeow] play (kitten)[v:SearchTerm]")
+  plan (Y2BnEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhikkzIrkir1EktTMvNBgqlFeo4gtmdeWj6DPIoep9LMnBSQJoQCMRQFcDk0y9wy88D6GMRRhINTE4uSM0JSi3IZ2BgYGZgYmBlYGFiBbAYkHiOYB8EMQFFGkDwA)
+  last-modified (1565661511801)
+}

--- a/audio/resources/en/training/t-c.training.bxb
+++ b/audio/resources/en/training/t-c.training.bxb
@@ -1,0 +1,5 @@
+train (t-ccjuuba2a46857hymfzeqkves) {
+  utterance ("[g:PlayMeow] Play (meow)[v:SearchTerm]")
+  plan (Y2BnEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhikkzIrkir1EktTMvNBgqlFeo4gtmdeWj6DPIoep9LMnBSQJoQCMRQFcDk0y9wy88D6GMRRhINTE4uSM0JSi3IZ2BgYGZgYmBlYGFiBbAYkHiOYB8EMQFFGkDwA)
+  last-modified (1565661439394)
+}

--- a/audio/resources/en/training/t-u.training.bxb
+++ b/audio/resources/en/training/t-u.training.bxb
@@ -1,5 +1,5 @@
 train (t-ut2tvnte4zm7iec5em7zj93pz) {
   utterance ([g:PlayMeow] Say meow)
-  plan (Y2BiEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhgYgZABioEkAA==)
-  last-modified (1562020494177)
+  plan (Y2BmEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhikkzIrkir1EktTMvNBgqlFeo4gtmdeWj4DEwMjEDMASUYGBhgNAA==)
+  last-modified (1565661410233)
 }

--- a/audio/resources/en/training/t-w.training.bxb
+++ b/audio/resources/en/training/t-w.training.bxb
@@ -1,0 +1,5 @@
+train (t-wb8xz3fo2y7925rjpaegdcknc) {
+  utterance ("[g:PlayMeow] Play (cat)[v:SearchTerm]")
+  plan (Y2BnEE6tSMwtyEnVy03NL9cLSi0uzSlhEEURDMhJrPQFMhikkzIrkir1EktTMvNBgqlFeo4gtmdeWj6DPIoep9LMnBSQJoQCMRQFcDk0y9wy88D6GMRRhINTE4uSM0JSi3IZ2BgYGZgYmBlYGFiBbAYkHiOYB8EMQFFGkDwA)
+  last-modified (1565661464549)
+}


### PR DESCRIPTION
- Changed PlayMeow's computed-input for linking BuildMeowAudioInfo action into a regular input, and linked the action using default-init to allow NL input to be used in a lower level action, FindMeow.

- BuildMeowAudioInfo demonstrates how to build an audioItem and then audioInfo
-- links FindMeow action via default-init for the reason mentioned above.

- FindMeow action takes in a searchTerm input and does a basic `includes` search on the three audio objects.