### PR TITLE
Updated viv.money version to latest to remove compile error

### DIFF
--- a/http-api-calls/capsule.bxb
+++ b/http-api-calls/capsule.bxb
@@ -18,7 +18,7 @@ capsule {
     }
     import (viv.money) { 
       as (money) 
-      version (2.20.12)
+      version (2.21.14)
     }
   }
 }


### PR DESCRIPTION
This example had compile errors due to the deprecated viv.money version - upgraded viv.money to 2.21.14