### PR TITLE
update the http endpoints

### DIFF
--- a/http-api-calls/README.md
+++ b/http-api-calls/README.md
@@ -31,7 +31,7 @@ For more information see - https://bixbydevelopers.com/dev/docs/sample-capsules/
 #### Tutorial Video on HTTP calls
 [![Watch the video](https://i.ytimg.com/vi/Z7J0eGmPRA4/hqdefault.jpg)](https://youtu.be/Z7J0eGmPRA4)
 
-If you want to see the contents of the endpoint this capsule uses (at http://shoe.bixby.pro/), but cannot access the link, you can view the data in endpointContents.zip. You can also see the data the endpoint returned in the Debug Console, if you click on the action (i.e. FindShoe), then click on 'requests'.
+If you want to see the contents of the endpoint this capsule uses (at https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collection/), but cannot access the link, you can view the data in endpointContents.zip. You can also see the data the endpoint returned in the Debug Console, if you click on the action (i.e. FindShoe), then click on 'requests'.
 
 ---
 

--- a/http-api-calls/capsule.bxb
+++ b/http-api-calls/capsule.bxb
@@ -1,6 +1,6 @@
 capsule {
   id (example.http)
-  version (1.0.1)
+  version (1.1.0)
   format (3)
   targets {
     target (bixby-mobile-en-US)

--- a/http-api-calls/code/CreateShoe.js
+++ b/http-api-calls/code/CreateShoe.js
@@ -20,7 +20,7 @@ module.exports.function = function createShoe () {
     format: 'json'
   };
 
-  var response = http.postUrl('http://shoe.bixby.pro/shoes', shoe, options);
+  var response = http.postUrl('https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collection/shoes', shoe, options);
 
   console.log(response);
   return response.parsed;

--- a/http-api-calls/code/FindShoe.js
+++ b/http-api-calls/code/FindShoe.js
@@ -6,7 +6,7 @@ module.exports.function = function findShoe () {
   // from capsule.properties, this would look like this
   // var response = http.getUrl(config.get('remote.url') + '/shoes', { format: 'json' });
 
-  var response = http.getUrl('http://shoe.bixby.pro/shoes', { format: 'json' });
+  var response = http.getUrl('https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collection/shoes', { format: 'json' });
   console.log ("response = " + response)
   return response;
 }

--- a/http-api-calls/code/FindShoeError.js
+++ b/http-api-calls/code/FindShoeError.js
@@ -4,7 +4,7 @@ var fail = require('fail')
 module.exports.function = function findShoeError () {
   try {
     // This call will throw a 500, and the http library will throw a JavaScript error that you can catch.
-    var response = http.getUrl('http://shoe.bixby.pro/error', { format: 'json' });
+    var response = http.getUrl('https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collectio', { format: 'json' });
   } catch (e) {
     console.log(e);
     throw fail.checkedError('This error will cause a halt.', 'ErrorWhichHalts', {})

--- a/http-api-calls/code/FindShoeError.js
+++ b/http-api-calls/code/FindShoeError.js
@@ -3,7 +3,7 @@ var console = require('console')
 var fail = require('fail')
 module.exports.function = function findShoeError () {
   try {
-    // This call will throw a 500, and the http library will throw a JavaScript error that you can catch.
+    // This call will throw a 404, and the http library will throw a JavaScript error that you can catch.
     var response = http.getUrl('https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collectio', { format: 'json' });
   } catch (e) {
     console.log(e);

--- a/http-api-calls/code/FindShoeFiltering.js
+++ b/http-api-calls/code/FindShoeFiltering.js
@@ -9,6 +9,6 @@ module.exports.function = function findShoe (type) {
     }
   };
   // makes a GET call to /shoes?type=Formal
-  var response = http.getUrl('http://shoe.bixby.pro/shoes', options);
+  var response = http.getUrl('https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collection/shoes', options);
   return response;
 }

--- a/http-api-calls/code/FindShoeReturnHeaders.js
+++ b/http-api-calls/code/FindShoeReturnHeaders.js
@@ -4,7 +4,7 @@ module.exports.function = function findShoeReturnHeaders () {
 
   // This call will throw a 500, but since we are using returnHeaders: true,
   // we must check for the error ourselves.
-  var errorResponse = http.getUrl('http://shoe.bixby.pro/error', { format: 'json', returnHeaders: true });
+  var errorResponse = http.getUrl('https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collectio', { format: 'json', returnHeaders: true });
   
   console.log(errorResponse);
   
@@ -12,7 +12,7 @@ module.exports.function = function findShoeReturnHeaders () {
     console.log("There was an error.");
   }
 
-  var successResponse = http.getUrl('http://shoe.bixby.pro/shoes', { format: 'json', returnHeaders: true });
+  var successResponse = http.getUrl('https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collection/shoes', { format: 'json', returnHeaders: true });
   
   console.log(successResponse);
   

--- a/http-api-calls/code/FindShoeReturnHeaders.js
+++ b/http-api-calls/code/FindShoeReturnHeaders.js
@@ -2,13 +2,13 @@ var http = require('http')
 var console = require('console')
 module.exports.function = function findShoeReturnHeaders () {
 
-  // This call will throw a 500, but since we are using returnHeaders: true,
+  // This call will throw a 404, but since we are using returnHeaders: true,
   // we must check for the error ourselves.
   var errorResponse = http.getUrl('https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collectio', { format: 'json', returnHeaders: true });
   
   console.log(errorResponse);
   
-  if (errorResponse.status === 500) {
+  if (errorResponse.status === 404) {
     console.log("There was an error.");
   }
 

--- a/http-api-calls/resources/base/endpoints.bxb
+++ b/http-api-calls/resources/base/endpoints.bxb
@@ -13,7 +13,7 @@ endpoints {
     
     action-endpoint (FindShoeRemoteEndpoint) {
       accepted-inputs ()
-      remote-endpoint ("http://shoe.bixby.pro/shoes") {
+      remote-endpoint ("https://my-json-server.typicode.com/bixbydevelopers/capsule-samples-collection/shoes") {
         method (GET)
       }
     }


### PR DESCRIPTION
- gets data from https://github.com/bixbydevelopers/capsule-samples-collection/blob/master/db.json via https://my-json-server.typicode.com/
- keeps the same behavior as before in all actions
- only changes are the endpoint url and using incomplete url to retrieve 404 error instead of expecting a 500 from the server